### PR TITLE
Add QALD-9-Plus data

### DIFF
--- a/data/qald_9_plus/README.md
+++ b/data/qald_9_plus/README.md
@@ -1,0 +1,5 @@
+# Data description
+
+This is the part of the original [QALD-9-plus](https://github.com/KGQA/qald_9_plus) dataset over Wikidata. The following changes were made to it:
+* The field `answers` was obtained based on the following SPARQL [endpoint](http://sems-vm-1.informatik.uni-hamburg.de:443/api/endpoint/sparql).
+* The questions with empty answer sets were eliminated.


### PR DESCRIPTION
As discussed in https://github.com/KGQA/qald_9_plus/pull/2

# Data description

This is the part of the original [QALD-9-plus](https://github.com/KGQA/qald_9_plus) dataset over Wikidata. The following changes were made to it:
* The field `answers` was obtained based on the following SPARQL [endpoint](http://sems-vm-1.informatik.uni-hamburg.de:443/api/endpoint/sparql).
* The questions with empty answer sets were eliminated.